### PR TITLE
Revert "sepolicy: Fix target selection"

### DIFF
--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -11,7 +11,7 @@ BOARD_PLAT_PUBLIC_SEPOLICY_DIR += \
 BOARD_PLAT_PRIVATE_SEPOLICY_DIR += \
     device/qcom/sepolicy/qva/private
 
-ifneq (,$(filter $(UM_4_14_FAMILY), $(TARGET_BOARD_PLATFORM)))
+ifeq (,$(filter sdm845 sdm710, $(TARGET_BOARD_PLATFORM)))
     BOARD_SEPOLICY_DIRS += \
         device/qcom/sepolicy/generic/vendor/common \
         device/qcom/sepolicy/qva/vendor/common/sysmonapp \
@@ -31,7 +31,9 @@ ifneq (,$(filter $(UM_4_14_FAMILY), $(TARGET_BOARD_PLATFORM)))
       BOARD_SEPOLICY_DIRS += device/qcom/sepolicy/generic/vendor/test
       BOARD_SEPOLICY_DIRS += device/qcom/sepolicy/qva/vendor/test
     endif
-else
+endif
+
+ifneq (,$(filter sdm845 sdm710, $(TARGET_BOARD_PLATFORM)))
     BOARD_SEPOLICY_DIRS += \
         device/qcom/sepolicy/legacy/vendor/common/sysmonapp \
         device/qcom/sepolicy/legacy/vendor/ssg \


### PR DESCRIPTION
* UM_4_14_FAMILY isn't defined by the time sepolicy.mk is included.

This reverts commit d4266182f85cd128c60bf365b200817234618d81.

Change-Id: Ie07c1994c73bd2b2c55b02669c29e31c1dc31528